### PR TITLE
[Frontend] Add Redux store [2/3]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
 import "css/global/Global.css";
 import "css/global/colors/ColorVariables.css";
 
+import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
+import store from "./_redux/store";
+
 import Routes from "./Routes";
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes />
+      <Provider store={store}>
+        <Routes />
+      </Provider>
     </BrowserRouter>
   );
 }

--- a/src/_redux/slices/itemSlice.ts
+++ b/src/_redux/slices/itemSlice.ts
@@ -1,0 +1,70 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import mockData from "mock_data/stackline_frontend_assessment_data_2021.json";
+
+// I typed this manually however, it's better to auto-generate data types from a backend schema
+type Item = {
+  brand: string;
+  details: Array<string>;
+  id: string;
+  image: string;
+  retailer: string;
+  reviews: Array<Record<string, string | number>>;
+  sales: Array<Record<string, string | number>>;
+  subtitle: string;
+  tags: Array<string>;
+  title: string;
+};
+
+type ItemState = {
+  data: Array<Item>;
+  error: string | null;
+  loading: boolean;
+};
+
+const initialState: ItemState = {
+  data: [],
+  error: null,
+  loading: false,
+};
+
+// Create an async thunk for fetching data
+export const fetchMockItemData = createAsyncThunk(
+  "item/fetchMockItemData",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response: { data: Array<Item>; ok: boolean } = {
+        data: mockData,
+        ok: true,
+      };
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const { data } = response;
+      return data;
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  },
+);
+
+// Create the data slice
+export const itemSlice = createSlice({
+  extraReducers: (builder) => {
+    builder.addCase(fetchMockItemData.pending, (state: ItemState) => {
+      state.loading = true;
+    });
+    builder.addCase(fetchMockItemData.fulfilled, (state, action) => {
+      state.loading = false;
+      state.data = action.payload;
+    });
+    builder.addCase(fetchMockItemData.rejected, (state, action) => {
+      state.loading = false;
+      state.error = (action.payload as string) || "Failed to fetch";
+    });
+  },
+  initialState,
+  name: "item",
+  reducers: {},
+});
+
+export const itemReducer = itemSlice.reducer;

--- a/src/_redux/store.ts
+++ b/src/_redux/store.ts
@@ -1,0 +1,16 @@
+import { itemReducer } from "_redux/slices/itemSlice";
+
+import { configureStore } from "@reduxjs/toolkit";
+
+const store: any = configureStore({
+  reducer: {
+    item: itemReducer,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {items: ItemState}
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/src/hooks/useDispatch.ts
+++ b/src/hooks/useDispatch.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import type { RootState, AppDispatch } from "_redux/store";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
- Integrate Redux store to the app (Redux ToolKit specifically)
- Add a slice for Item(s)
- Create the reducer and action for fetching our mock Item data